### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libnet-ldapapi-perl (3.0.7-3) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Fri, 21 Oct 2022 08:01:29 -0000
+
 libnet-ldapapi-perl (3.0.7-2) unstable; urgency=medium
 
   * Update to debhelper compatibility level v13.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ libnet-ldapapi-perl (3.0.7-3) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Fri, 21 Oct 2022 08:01:29 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 libnet-ldapapi-perl (3.0.7-3) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Fri, 21 Oct 2022 08:01:29 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Rules-Requires-Root: no
 Maintainer: Bill MacAllister <bill@ca-zephyr.org>
 Uploaders:
  Russ Allbery <rra@debian.org>,
-Standards-Version: 4.5.1
+Standards-Version: 4.6.1
 Homepage: https://github.com/quanah/net-ldapapi
 Vcs-Browser: https://github.com/whm/libnet-ldapapi-perl
 Vcs-Git: https://github.com/whm/libnet-ldapapi-perl.git

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Uploaders:
 Standards-Version: 4.5.1
 Homepage: https://github.com/quanah/net-ldapapi
 Vcs-Browser: https://github.com/whm/libnet-ldapapi-perl
-Vcs-Git: https://github.com/whm/libnet-ldapapi-perl
+Vcs-Git: https://github.com/whm/libnet-ldapapi-perl.git
 
 Package: libnet-ldapapi-perl
 Architecture: any

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+---
+Repository-Browse: https://github.com/quanah/net-ldapapi


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing))

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/libnet-ldapapi-perl/1f040088-552c-4c5e-9bd9-636e4fb9ab2c.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/e1/eada83b528bcf4962c5354e9943284ea7a3e5d.debug
    -rw-r--r--  root/root   /usr/lib/x86_64-linux-gnu/perl5/5.36/Net/LDAPapi.pm
    -rw-r--r--  root/root   /usr/lib/x86_64-linux-gnu/perl5/5.36/auto/Net/LDAPapi/LDAPapi.so
    -rw-r--r--  root/root   /usr/lib/x86_64-linux-gnu/perl5/5.36/auto/Net/LDAPapi/autosplit.ix
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/2a/04597cfe222fe3d129a852704d46e34ef4c21c.debug
    -rw-r--r--  root/root   /usr/lib/x86_64-linux-gnu/perl5/5.34/Net/LDAPapi.pm
    -rw-r--r--  root/root   /usr/lib/x86_64-linux-gnu/perl5/5.34/auto/Net/LDAPapi/LDAPapi.so
    -rw-r--r--  root/root   /usr/lib/x86_64-linux-gnu/perl5/5.34/auto/Net/LDAPapi/autosplit.ix
### Control files of package libnet-ldapapi-perl: lines which differ (wdiff format)
* Depends: libconvert-asn1-perl, perl (>= [-5.34.0-5), perlapi-5.34.0,-] {+5.36.0-4), perlapi-5.36.0,+} libc6 (>= 2.4), libldap-2.5-0 (>= 2.5.4)
### Control files of package libnet-ldapapi-perl-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-2a04597cfe222fe3d129a852704d46e34ef4c21c-] {+e1eada83b528bcf4962c5354e9943284ea7a3e5d+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1f040088-552c-4c5e-9bd9-636e4fb9ab2c/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1f040088-552c-4c5e-9bd9-636e4fb9ab2c/diffoscope)).
